### PR TITLE
feat (infra): [network] disable default outbound access

### DIFF
--- a/infra-as-code/bicep/network.bicep
+++ b/infra-as-code/bicep/network.bicep
@@ -56,6 +56,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
         // App services plan subnet
         name: 'snet-appServicePlan'
         properties: {
+          defaultOutboundAccess: false
           addressPrefix: appServicesSubnetPrefix
           delegations: [
             {
@@ -74,6 +75,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
         // App Gateway subnet
         name: 'snet-appGateway'
         properties: {
+          defaultOutboundAccess: false
           addressPrefix: appGatewaySubnetPrefix
           delegations: []
           networkSecurityGroup: {
@@ -176,6 +178,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
         // Workload firewall for all egress traffic
         name: 'AzureFirewallSubnet'
         properties: {
+          defaultOutboundAccess: false
           addressPrefix: azureFirewallSubnetPrefix
           delegations: []
           privateEndpointNetworkPolicies: 'Disabled'
@@ -186,6 +189,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
         // Workload firewall for all egress traffic
         name: 'AzureFirewallManagementSubnet'
         properties: {
+          defaultOutboundAccess: false
           addressPrefix: azureFirewallManagementSubnetPrefix
           delegations: []
           privateEndpointNetworkPolicies: 'Disabled'


### PR DESCRIPTION
## WHY

we wanted to explicitly disable outbound access, means no default outbound access from all subnet where changing this setting is allowed. We wanted to ensure that AIFoundry baseline is working and enforcing this setup since default access is being retired on September 2025

## WHAT Changed

- `app service`, `app-gateway` and `firewall` subnets are now marked with default outbound access as `false` 

## TEST

e2e: client -> appgw -> app-service -> ai foundry agents service
<img width="1788" height="1854" alt="image" src="https://github.com/user-attachments/assets/875672a4-569d-4113-ade6-9be5bed9f058" />

all subnets
<img width="1136" height="1304" alt="image" src="https://github.com/user-attachments/assets/c671f6ea-ddbb-410d-9042-64532c8bab84" />
