### PR TITLE
feat (infra): [aifoundry] add resource locks for AI Foundry Project Capability Host dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,14 @@ Most Azure resources deployed in the prior steps will incur ongoing charges unle
 
 Additionally, a few of the resources deployed enter soft delete status which will restrict the ability to redeploy another resource with the same name or DNS entry; and might not release quota. It's best to purge any soft deleted resources once you are done exploring. Use the following commands to delete the deployed resources and resource group and to purge each of the resources with soft delete.
 
+1. Delete the resource level locks for AI Foundry Project Capability Host dependencies
+
+   ```bash
+   az lock delete -g $RESOURCE_GROUP --resource-type 'Microsoft.Storage/storageAccounts' --resource stagent${BASE_NAME} -n stagent${BASE_NAME}-lock
+   az lock delete -g $RESOURCE_GROUP --resource-type 'Microsoft.DocumentDB/databaseAccounts' --resource cdb-ai-agent-threads-${BASE_NAME} -n cdb-ai-agent-threads-${BASE_NAME}-lock
+   az lock delete -g $RESOURCE_GROUP --resource-type 'Microsoft.Search/searchServices' --resource ais-ai-agent-vector-store-${BASE_NAME} -n ais-ai-agent-vector-store-${BASE_NAME}-lock
+   ```
+
 1. Delete the resource group as a way to delete all contained Azure resources.
 
    | :warning: | This will completely delete any data you may have included in this example. That data and this deployment will be unrecoverable. |

--- a/infra-as-code/bicep/ai-agent-blob-storage.bicep
+++ b/infra-as-code/bicep/ai-agent-blob-storage.bicep
@@ -175,10 +175,10 @@ resource azureDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-prev
 
 resource agentStorageAccountLocks 'Microsoft.Authorization/locks@2020-05-01' = {
   scope: agentStorageAccount
-  name: '${agentStorageAccount.name}-lock' 
+  name: '${agentStorageAccount.name}-lock'
   properties: {
     level: 'CanNotDelete'
-    notes: 'Prevent Accidental Changes in AI Foundry Capability Host Agent Knowledge Storage Account'
+    notes: 'Prevent deleting; recovery not practical. Hard dependency for your AI Foundry Agent Service.'
     owners: []
   }
 }

--- a/infra-as-code/bicep/ai-agent-blob-storage.bicep
+++ b/infra-as-code/bicep/ai-agent-blob-storage.bicep
@@ -171,6 +171,18 @@ resource azureDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-prev
   }
 }
 
+// Prevent Accidental Changes
+
+resource agentStorageAccountLocks 'Microsoft.Authorization/locks@2020-05-01' = {
+  scope: agentStorageAccount
+  name: '${agentStorageAccount.name}-lock' 
+  properties: {
+    level: 'CanNotDelete'
+    notes: 'Prevent Accidental Changes in AI Foundry Capability Host Agent Knowledge Storage Account'
+    owners: []
+  }
+}
+
 // ---- Outputs ----
 
 output storageAccountName string = agentStorageAccount.name

--- a/infra-as-code/bicep/ai-search.bicep
+++ b/infra-as-code/bicep/ai-search.bicep
@@ -142,7 +142,7 @@ resource azureAiSearchServiceLocks 'Microsoft.Authorization/locks@2020-05-01' = 
   name: '${azureAiSearchService.name}-lock'
   properties: {
     level: 'CanNotDelete'
-    notes: 'Prevent Accidental Changes in AI Foundry Capability Host Agent Index AI Search Service'
+    notes: 'Prevent deleting; recovery not practical. Hard dependency for your AI Foundry Agent Service.'
     owners: []
   }
 }

--- a/infra-as-code/bicep/ai-search.bicep
+++ b/infra-as-code/bicep/ai-search.bicep
@@ -135,6 +135,18 @@ resource aiSearchPrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01'
   }
 }
 
+// Prevent Accidental Changes
+
+resource azureAiSearchServiceLocks 'Microsoft.Authorization/locks@2020-05-01' = {
+  scope: azureAiSearchService
+  name: '${azureAiSearchService.name}-lock'
+  properties: {
+    level: 'CanNotDelete'
+    notes: 'Prevent Accidental Changes in AI Foundry Capability Host Agent Index AI Search Service'
+    owners: []
+  }
+}
+
 // ---- Outputs ----
 
 output aiSearchName string = azureAiSearchService.name

--- a/infra-as-code/bicep/cosmos-db.bicep
+++ b/infra-as-code/bicep/cosmos-db.bicep
@@ -207,7 +207,7 @@ resource cosmosDbAccountLocks 'Microsoft.Authorization/locks@2020-05-01' = {
   name: '${cosmosDbAccount.name}-lock'
   properties: {
     level: 'CanNotDelete'
-    notes: 'Prevent Accidental Changes in AI Foundry Capability Host Agent Thread Cosmos DB Account'
+    notes: 'Prevent deleting; recovery not practical. Hard dependency for your AI Foundry Agent Service.'
     owners: []
   }
 }

--- a/infra-as-code/bicep/cosmos-db.bicep
+++ b/infra-as-code/bicep/cosmos-db.bicep
@@ -200,6 +200,18 @@ resource assignDebugUserToCosmosAccountReader 'Microsoft.Authorization/roleAssig
   }
 }
 
+// Prevent Accidental Changes
+
+resource cosmosDbAccountLocks 'Microsoft.Authorization/locks@2020-05-01' = {
+  scope: cosmosDbAccount
+  name: '${cosmosDbAccount.name}-lock'
+  properties: {
+    level: 'CanNotDelete'
+    notes: 'Prevent Accidental Changes in AI Foundry Capability Host Agent Thread Cosmos DB Account'
+    owners: []
+  }
+}
+
 // ---- Outputs ----
 
 output cosmosDbAccountName string = cosmosDbAccount.name


### PR DESCRIPTION
## WHY

We want to prevent accidental deletions of critical AI Foundry Project capability host dependencies that might cause disruption. This way we reduce the number of potential incidents that might affect this architectured.

## WHAT Change?

- add a cannot delete lock to Thread storage (Cosmos DB)
- add a cannot delete lock to Index/Knowlege storage (Storage Account)
- add a cannot delete lock to Vector store (AI Search Service)
- add instructions to delete resource level locks before cleaning up

## TEST

<img width="2111" height="22" alt="image" src="https://github.com/user-attachments/assets/3ff142b3-f064-44a9-825d-b06c641a4c5e" />

<img width="2111" height="21" alt="image" src="https://github.com/user-attachments/assets/0c154ec1-c95f-4c59-953f-b08f6a1ea939" />

<img width="1983" height="23" alt="image" src="https://github.com/user-attachments/assets/53622508-e617-4a99-9173-bd74c78c7c3b" />