### PR TITLE
feat (docs): [networking] bing traffic guidance accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Azure AI Foundry hosts Azure AI Foundry Agent Service as a capability. Foundry A
 1. When the web application receives a user query or instruction, it invokes the purpose-built agent. The web application communicates with the agent via the Azure AI Agent SDK. The web application calls the agent over a private endpoint and authenticates to Azure AI Foundry by using its managed identity.
 1. The agent processes the user's request based on the instructions in its system prompt. To fulfill the user's intent, the agent uses a configured language model and connected tools and knowledge stores.
 1. The agent connects to the knowledge store (Azure AI Search) in the private network via a private endpoint.
-1. Requests to external knowledge stores or tools, such as Wikipedia or Bing, traverse Azure Firewall for inspection and egress policy enforcement.
+1. Requests to most external knowledge stores or tools, such as Wikipedia, traverse Azure Firewall for inspection and egress policy enforcement. Some of AI Foundry's built-in connections might not support egressing through your subnet.
 1. The agent connects to its configured language model and passes relevant context.
 1. Before the agent returns the response to the UI, it persists the request, the generated response, and a list of consulted knowledge stores into a dedicated memory database. This database maintains the complete conversation history, which enables context-aware interactions and allows users to resume conversations with the agent without losing prior context.
 

--- a/infra-as-code/bicep/azure-firewall.bicep
+++ b/infra-as-code/bicep/azure-firewall.bicep
@@ -147,7 +147,7 @@ resource azureFirewallPolicy 'Microsoft.Network/firewallPolicies@2024-05-01' = {
               webCategories: []
               targetFqdns: [
                  '*'
-                 // 'api.bing.microsoft.com' // Production readiness change: refine your target FQDNs to restrict egress traffic exclusively to the external services and endpoints your agent depends on. For instance this fqnd scopes access specifically to Grounding with Bing.
+                 // 'api.example.org' // Production readiness change: refine your target FQDNs to restrict egress traffic exclusively to the external services and endpoints your agent depends on.
               ]
               targetUrls: []
               terminateTLS: false


### PR DESCRIPTION
## WHY

we wanted to remove bing as an example for traversing traffic through az fw or even flowing/egressing through a private subnet since that is actually happening at the azure backbone network instead

## WHAT Changed?

- readme remove bing and offers a more general guidance
- fw target fqdns is now using a fake example

## TEST

you read the docs and bing doesn't read as traffic it is possible to egress through your subnet